### PR TITLE
Fixed cardview dependency to match targetSdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.0"'
-    compile "com.android.support:design:23.1.0"
+    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:design:23.1.0'
+    compile 'com.android.support:cardview-v7:23.1.0'
     compile 'de.hdodenhof:circleimageview:1.3.0'
-    compile 'com.android.support:cardview-v7:22.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
-
-
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 


### PR DESCRIPTION
Otherwise there is a warning: This support library should not use a lower version (22) than the targetSdkVersion (23).
Also bumped gradle plugin version to latest stable version.